### PR TITLE
Show plain solution string

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -125,7 +125,7 @@ def post_answer(payload: AnswerIn, request: Request) -> AnswerOut:
     if not correct:
         # Prefer the explicit solution; else prettify the first pattern
         solution = question.get("solution") or _humanise(question["patterns"][0])
-        feedback  = f"{feedback}\n\n💡 Correct answer: **{solution}**"
+        feedback  = f"{feedback}\n\n{solution}"
 
     return AnswerOut(correct=correct, feedback=feedback)
 
@@ -164,3 +164,10 @@ def get_solution(question_id: int) -> str:
 
     # Prefer explicit solution → fall back to a prettified regex
     return q.get("solution") or _humanise(q["patterns"][0])
+
+
+# --------------------------------------------------------------------------- #
+# Ensure question cache is populated even if startup events do not run
+# --------------------------------------------------------------------------- #
+
+_warm_cache()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,4 +13,6 @@ def test_post_answer_validation(client):
     q = client.get("/question").json()
     # Intentionally wrong answer:
     r = client.post("/answer", json={"id": q["id"], "cmd": "foo"}).json()
-    assert r == {"correct": False, "feedback": "❌ Not quite—try again."}
+    solution = client.get(f"/solution/{q['id']}").json()
+    assert r == {"correct": False,
+                 "feedback": f"❌ Not quite—try again.\n\n{solution}"}


### PR DESCRIPTION
## Summary
- show the solution string without markup when an answer is wrong
- ensure the question cache warms on import so tests work
- update API test to expect clean solution output

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684165aaf8c083238bc80cfbbb720db1